### PR TITLE
Remove dead Slack token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT = holdem
 REGISTRY = registry.giantswarm.io
 USERNAME := $(shell swarm user)
 ORG := $(shell swarm env | cut -d/ -f1)
-SLACK_TOKEN="xoxb-10023012097-Nw7snCikE770UpvcS5tFkNCg"
+SLACK_TOKEN=""
 
 # local info
 MY_IP = $(shell boot2docker ip)


### PR DESCRIPTION
This token is invalid but Giant Swarm gets reports about it being here
cc @kordless 